### PR TITLE
Added DEFAULT_MEDIA_RECEIVER_APP_ID constant

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -219,6 +219,10 @@ chrome.cast = {
 
 	// media package
 	media: {
+		/**
+		* The default receiver app.
+		*/
+		DEFAULT_MEDIA_RECEIVER_APP_ID: 'CC1AD845',
 
 		/**
 		 * Possible states of the media player.


### PR DESCRIPTION
I added the "DEFAULT_MEDIA_RECEIVER_APP_ID" to chrome.media to match the constant in the original Chrome API. A small thing, but this should get people up and running more quickly. 
