### PR TITLE
Implemented support for metadata GENERIC type

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -683,8 +683,7 @@ chrome.cast.Session.prototype.loadMedia = function (loadRequest, successCallback
 	var self = this;
 
 	var mediaInfo = loadRequest.media;
-	execute('loadMedia', mediaInfo.contentId, mediaInfo.contentType, mediaInfo.duration || 0.0, mediaInfo.streamType, loadRequest.autoplay || false, loadRequest.currentTime || 0, function(err, obj) {
-		if (!err) {
+	execute('loadMedia', mediaInfo.contentId, mediaInfo.contentType, mediaInfo.duration || 0.0, mediaInfo.streamType, loadRequest.autoplay || false, loadRequest.currentTime || 0, mediaInfo.metadata, function(err, obj) {
 			_currentMedia = new chrome.cast.media.Media(self.sessionId, obj.mediaSessionId);
 			_currentMedia.media = mediaInfo;
 

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -440,10 +440,10 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
      * @param  loadReuqest.currentTime Where to begin playing from
      * @param  callbackContext 
      */
-    public boolean loadMedia (String contentId, String contentType, Integer duration, String streamType, Boolean autoPlay, Double currentTime, final CallbackContext callbackContext) {
+    public boolean loadMedia (String contentId, String contentType, Integer duration, String streamType, Boolean autoPlay, Double currentTime, JSONObject metadata, final CallbackContext callbackContext) {
         
     	if (this.currentSession != null) {
-    		return this.currentSession.loadMedia(contentId, contentType, duration, streamType, autoPlay, currentTime, 
+    		return this.currentSession.loadMedia(contentId, contentType, duration, streamType, autoPlay, currentTime, metadata,
     				new ChromecastSessionCallback() {
 
 						@Override

--- a/src/android/ChromecastMediaController.java
+++ b/src/android/ChromecastMediaController.java
@@ -1,5 +1,12 @@
 package acidhax.cordova.chromecast;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.net.Uri;
+import android.util.Log;
+
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.RemoteMediaPlayer;
@@ -7,6 +14,7 @@ import com.google.android.gms.cast.RemoteMediaPlayer.MediaChannelResult;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.images.WebImage;
 
 public class ChromecastMediaController {
 	private RemoteMediaPlayer remote = null;
@@ -15,8 +23,26 @@ public class ChromecastMediaController {
 	}
 	
 	public MediaInfo createLoadUrlRequest(String contentId, String contentType, long duration, String streamType) {
-		MediaMetadata mediaMetadata = new MediaMetadata(MediaMetadata.MEDIA_TYPE_MOVIE);
-//    	mediaMetadata.putString(MediaMetadata.KEY_TITLE, "My video");
+		
+        // Try creating a GENERIC MediaMetadata obj
+		MediaMetadata mediaMetadata = new MediaMetadata();
+		try {
+		
+			int metadataType = metadata.has("metadataType") ? metadata.getInt("metadataType") : MediaMetadata.MEDIA_TYPE_MOVIE;
+            
+			// GENERIC
+			if (metadataType == MediaMetadata.MEDIA_TYPE_GENERIC) {
+				mediaMetadata = new MediaMetadata(); // Creates GENERIC MediaMetaData
+				mediaMetadata.putString(MediaMetadata.KEY_TITLE, (metadata.has("title")) ? metadata.getString("title") : "[Title not set]" ); // TODO: What should it default to?
+				mediaMetadata.putString(MediaMetadata.KEY_SUBTITLE, (metadata.has("title")) ? metadata.getString("subtitle") : "[Subtitle not set]" ); // TODO: What should it default to?
+				mediaMetadata = addImages(metadata, mediaMetadata);
+			}
+			
+		} catch(Exception e) {
+			e.printStackTrace();
+			// Fallback
+			mediaMetadata = new MediaMetadata(MediaMetadata.MEDIA_TYPE_MOVIE);
+		}
 
     	int _streamType = MediaInfo.STREAM_TYPE_BUFFERED;
     	if (streamType.equals("buffered")) {
@@ -93,4 +119,20 @@ public class ChromecastMediaController {
 		    }
 		};
 	}
+    
+    private MediaMetadata addImages(JSONObject metadata, MediaMetadata mediaMetadata) throws JSONException {
+        if (metadata.has("images")) {
+            JSONArray imageUrls = metadata.getJSONArray("images");
+            for (int i=0; i<imageUrls.length(); i++) {
+                JSONObject imageObj = imageUrls.getJSONObject(i); 
+                String imageUrl = imageObj.has("url") ? imageObj.getString("url") : "undefined";
+                if (imageUrl.indexOf("http://")<0) { continue; } // TODO: don't add image?
+                Uri imageURI = Uri.parse( imageUrl );
+                WebImage webImage = new WebImage(imageURI);
+                mediaMetadata.addImage(webImage);
+            }
+        }
+        return mediaMetadata;
+    }
+    
 }

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -183,9 +183,9 @@ public class ChromecastSession
 	 * @param callback
 	 * @return
 	 */
-	public boolean loadMedia(String contentId, String contentType, long duration, String streamType, boolean autoPlay, double currentTime, final ChromecastSessionCallback callback) {
+	public boolean loadMedia(String contentId, String contentType, long duration, String streamType, boolean autoPlay, double currentTime, JSONObject metadata, final ChromecastSessionCallback callback) {
 		try {
-			MediaInfo mediaInfo = chromecastMediaController.createLoadUrlRequest(contentId, contentType, duration, streamType);
+			MediaInfo mediaInfo = chromecastMediaController.createLoadUrlRequest(contentId, contentType, duration, streamType, metadata);
 			
 			mRemoteMediaPlayer.load(mApiClient, mediaInfo, autoPlay, (long)(currentTime * 1000))
 				.setResultCallback(new ResultCallback<RemoteMediaPlayer.MediaChannelResult>() {


### PR DESCRIPTION
I've tested this in a fork I've built to work with an older Cordova version (2.7.0) but everything should check out. 

Notes:
- Not actually compiled because I don't have a full Eclipse project of this
- I may (read: probably) have forgotten an import statement in Chromecast.java and ChromecastSession.java
- Only supports MediaMetadata of type GENERIC at the moment.
- Has a fallback to MEDIA_TYPE_MOVIE when anything fails (like metadata being null)
