### PR TITLE
Added 'leave' command to session object

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -642,6 +642,26 @@ chrome.cast.Session.prototype.stop = function (successCallback, errorCallback) {
 };
 
 /**
+ * Leaves the current session.
+ * @param {function} successCallback 
+ * @param {function} errorCallback   The possible errors are TIMEOUT, API_NOT_INITIALIZED, CHANNEL_ERROR, and EXTENSION_MISSING.
+ */
+chrome.cast.Session.prototype.leave = function (successCallback, errorCallback) {
+	if (chrome.cast.isAvailable === false) {
+		errorCallback(new chrome.cast.Error(chrome.cast.ErrorCode.API_NOT_INITIALIZED), 'The API is not initialized.', {});
+		return;
+	}
+
+	execute('sessionLeave', function(err) {
+		if (!err) {
+			successCallback && successCallback();
+		} else {
+			handleError(err, errorCallback);
+		}
+	});
+};
+
+/**
  * Sends a message to the receiver application on the given namespace. 
  * The successCallback is invoked when the message has been submitted to the messaging channel. 
  * Delivery to the receiver application is best effort and not guaranteed.

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -566,6 +566,23 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
     	return true;
     }
 
+    /**
+     * Stops the session
+     * @param callbackContext
+     * @return
+     */
+    public boolean sessionLeave (CallbackContext callbackContext) {
+        if (this.currentSession != null) {
+            this.currentSession.leave(genericCallback(callbackContext));
+            this.currentSession = null;
+            this.setLastSessionId("");
+        } else {
+            callbackContext.success();
+        }
+        
+        return true;
+    }
+
     public boolean emitAllRoutes(CallbackContext callbackContext) {
     	final Activity activity = cordova.getActivity();
     	

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -171,6 +171,19 @@ public class ChromecastSession
 //		Cast.CastApi.stopApplication(mApiClient);
 	}
 	
+	/**
+	 * Leaves the session.
+	 * @param callback
+	 */
+	public void leave (final ChromecastSessionCallback callback) {
+		try {
+			Cast.CastApi.leaveApplication(mApiClient);
+		} catch(Exception e) {
+			
+		}
+		
+		callback.onSuccess();
+	}	
 	
 	/**
 	 * Loads media over the media API


### PR DESCRIPTION
I noticed the session object was missing a "leave" function so I added it. Tested with a receiver app and all working.
