### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cordova-chromecast",
+  "version": "0.0.1",
+  "description": "Chromecast in Cordova.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/videostream/cordova-chromecast.git"
+  },
+  "keywords": [
+  ],
+  "author": "VideoStream",
+  "bugs": {
+    "url": "https://github.com/videostream/cordova-chromecast/issues"
+  },
+  "homepage": "https://github.com/videostream/cordova-chromecast"
+}


### PR DESCRIPTION
Hi,

I notice the package.json file is missing, without it we can’t install the plugin with recent version of Cordova.

